### PR TITLE
Apply license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+The JSON files contained within this repository are free of known copyright
+restrictions. Code contained within this repository is subject to the following
+license:
+
+MIT License
+
+Copyright (c) 2017 Minh Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This module merely repackages output from the MediaWiki API at the Wikimedia Meta-Wiki. There’s hardly any code beyond that output, but I’ve gone ahead and licensed it under the MIT license.

According to [this MediaWiki documentation](https://www.mediawiki.org/wiki/API:Licensing), we’d be expected to pass on the same license as the wiki’s license, in this case CC&nbsp;BY-SA. However, the site matrix output is identical across any Wikimedia wiki, including Wikidata, which applies a CC0 public domain dedication. So I added a short statement indicating that the JSON files in this repository are in the public domain.

Fixes #4.