### PR TITLE
Move to toolforge build-service

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,2 @@
+# used to serve the static files
+python3

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: scripts/web.sh
+update: scripts/update.sh

--- a/README.md
+++ b/README.md
@@ -5,3 +5,42 @@ The goal of this project is to provide filtered versions of [Wikimedia's site ma
 The data/ directory contains a prettified JSON file and a minified JSON file for each Wikimedia project. The all.json and all.min.json files include all the Wikimedia wikis, including not only the projects that have their own JSON files but also multilingual and special wikis.
 
 To update the JSON files, run `make`.
+
+
+## Running on toolforge
+To run on toolforge log into the tool accounnt:
+```
+ssh myuser@login.toolforge.org
+myuser@tools-sgebastion-10:$ become wmf-sitematrix
+wmf-sitematrix@tools-sgebastion-10:$
+```
+
+Start a build to pick up the new code
+```
+wmf-sitematrix@tools-sgebastion-10:$ toolforge build start https://github.com/osmlab/wmf-sitematrix
+... takes a minute
+```
+
+
+Start/restart the webservice mounting the NFS:
+```
+wmf-sitematrix@tools-sgebastion-10:$ toolforge webservice buildservice --mount=all restart
+```
+
+And create the job if it's not there to update `public_html/data/*json`:
+```
+wmf-sitematrix@tools-sgebastion-10:$ toolforge jobs run \
+    --schedule '0 0 */15 * *' \
+    --filelog \
+    --mount=all \
+    --image tool-wmf-sitematrix/tool-wmf-sitematrix:latest \
+    --command 'update' \
+    cron-tools.wmf-sitematrix-1
+```
+
+Or restart it if it exists and you want to run it right away:
+```
+wmf-sitematrix@tools-sgebastion-10:$ toolforge jobs restart cron-tools.wmf-sitematrix-1
+```
+
+Otherwise the next run will pull the new code.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,7 +11,7 @@ var projects = [
 ];
 
 var fs = require('fs');
-let dataPath = "data";
+let dataPath = `${process.env.TOOL_DATA_DIR}/public_html/data`;
 var data = JSON.parse(fs.readFileSync(`${dataPath}/all.json`, 'utf8'));
 
 console.log("Writing full site matrix...");

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+DEST_DIR="$TOOL_DATA_DIR/public_html/data"
+
+echo "Updating"
+
+mkdir -p "$DEST_DIR"
+wget -O "$DEST_DIR/all.json" 'https://meta.wikimedia.org/w/api.php?action=sitematrix&uselang=en&format=json'
+
+# For the first run in case there's nothing there
+cp --update data/*.json "$DEST_DIR/"
+node scripts/build.js
+echo "Update finished"

--- a/scripts/web.sh
+++ b/scripts/web.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+python -m http.server \
+    --bind "0.0.0.0" \
+    --directory "$TOOL_DATA_DIR/public_html/data" \
+    "$PORT"


### PR DESCRIPTION
This adds:
* Procfile + web.sh to run the web server
* http-server module to serve the generated json files
* Used the $TOOl_DATA_DIR in build.js to generate the files in the right path.
* Added info in the readme